### PR TITLE
Jshintrc review

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -6,8 +6,8 @@
   "forin": false,
   "freeze": true,
   "funcscope": false,
+  "jquery": true,
   "globals": {
-    "$": false,
     "wpAjax": false,
     "pages": false,
     "console": false,

--- a/.jshintrc
+++ b/.jshintrc
@@ -6,7 +6,6 @@
   "forin": false,
   "freeze": true,
   "funcscope": false,
-  "jquery": true,
   "globals": {
     "wpAjax": false,
     "pages": false,
@@ -18,6 +17,7 @@
     "ace": false
   },
   "iterator": false,
+  "jquery": true,
   "latedef": true,
   "maxcomplexity": 6,
   "maxdepth": 3,

--- a/.jshintrc
+++ b/.jshintrc
@@ -28,7 +28,6 @@
   "nocomma": true,
   "nonbsp": true,
   "nonew": true,
-  "notypeof": true,
   "predef": [],
   "shadow": "inner",
   "singleGroups": true,

--- a/.jshintrc
+++ b/.jshintrc
@@ -8,13 +8,12 @@
   "funcscope": false,
   "devel": true,
   "globals": {
-    "wpAjax": false,
-    "pages": false,
-    "console": false,
-    "resizeModalBody": false,
+    "ace": false,
     "getSelection": false,
-    "module": false,
-    "ace": false
+    "module": false, // environment option only available in ECS6
+    "pages": false, // passed through the plugins .php file
+    "resizeModalBody": false,
+    "wpAjax": false // passed through the plugins .php file
   },
   "iterator": false,
   "jquery": true,

--- a/.jshintrc
+++ b/.jshintrc
@@ -14,7 +14,6 @@
     "resizeModalBody": false,
     "getSelection": false,
     "module": false,
-    "require": false,
     "ace": false
   },
   "iterator": false,
@@ -27,6 +26,7 @@
   "maxstatements": 20,
   "noarg": true,
   "nocomma": true,
+  "node": true,
   "nonbsp": true,
   "nonew": true,
   "predef": [],

--- a/.jshintrc
+++ b/.jshintrc
@@ -10,10 +10,10 @@
   "globals": {
     "ace": false,
     "getSelection": false,
-    "module": false, // environment option only available in ECS6
-    "pages": false, // passed through the plugins .php file
+    "module": false,
+    "pages": false,
     "resizeModalBody": false,
-    "wpAjax": false // passed through the plugins .php file
+    "wpAjax": false
   },
   "iterator": false,
   "jquery": true,

--- a/.jshintrc
+++ b/.jshintrc
@@ -6,6 +6,7 @@
   "forin": false,
   "freeze": true,
   "funcscope": false,
+  "devel": true,
   "globals": {
     "wpAjax": false,
     "pages": false,


### PR DESCRIPTION
Closes #12 

Hey @AurelioDeRosa 

I didn't end up changing much, the major change was using `strict: implied` and removing the `use: strict` from the .js files.

I was wondering about the `varstmt` option - why would you use `let` / `const` over `var`?
